### PR TITLE
Expose handshake API to Papyrus

### DIFF
--- a/include/PapyrusAPI/Bindings.cpp
+++ b/include/PapyrusAPI/Bindings.cpp
@@ -139,6 +139,10 @@ namespace {
     bool RequestTheme(RE::StaticFunctionTag*, SkyPromptAPI::ClientID clientID, std::string theme_name) {
         return SkyPromptAPI::RequestTheme(clientID, theme_name);
     }
+
+    bool RequestHandshake(RE::StaticFunctionTag*, SkyPromptAPI::ClientID clientID, uint32_t key, uint32_t otherKey) {
+        return SkyPromptAPI::RequestHandshake(clientID, key, otherKey);
+    }
 }
 
 bool PapyrusAPI::Register(RE::BSScript::IVirtualMachine* vm) {
@@ -148,6 +152,7 @@ bool PapyrusAPI::Register(RE::BSScript::IVirtualMachine* vm) {
     vm->RegisterFunction("SendPromptForControl", "SkyPrompt", SendPromptForControl);
     vm->RegisterFunction("RemovePrompt", "SkyPrompt", RemovePrompt);
     vm->RegisterFunction("RequestTheme", "SkyPrompt", RequestTheme);
+    vm->RegisterFunction("RequestHandshake", "SkyPrompt", RequestHandshake);
 
     return true;
 }


### PR DESCRIPTION
## Summary

- Exposes `RequestHandshake` through SkyPrompt's existing Papyrus native bindings.
- Forwards the Papyrus client ID and two 32-bit keys directly to the existing C++ handshake API.
- Leaves the `SkyPrompt.psc` declaration for a follow-up, intentionally.

## Testing

- Compiled `include/PapyrusAPI/Bindings.cpp` successfully in Debug.