### PR TITLE
Fix directional and mouse key icons

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ cmake_minimum_required(VERSION 3.21)
 # Set your project name. This will be the name of your SKSE .dll file.
 set(AUTHOR_NAME "Quantumyilmaz")
 set(PRODUCT_NAME "SkyPrompt")
-project(${PRODUCT_NAME} VERSION 2.3.18.0 LANGUAGES CXX)
+project(${PRODUCT_NAME} VERSION 2.3.19.0 LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)

--- a/src/ImGui/IconsFonts.cpp
+++ b/src/ImGui/IconsFonts.cpp
@@ -259,6 +259,7 @@ namespace IconFont {
 
     const IconTexture* Manager::GetIcon(const std::uint32_t key) {
         switch (key) {
+            case KEY::kUp:
             case SKSE::InputMap::kGamepadButtonOffset_DPAD_UP:
                 return &upKey;
             case KEY::kDown:

--- a/src/ImGui/IconsFonts.h
+++ b/src/ImGui/IconsFonts.h
@@ -210,10 +210,12 @@ namespace IconFont {
             {256 + +MOUSE::kRightButton, IconTexture(L"Mouse2"sv)},
             {256 + +MOUSE::kMiddleButton, IconTexture(L"Mouse3"sv)},
             {256 + +MOUSE::kButton3, IconTexture(L"Mouse4"sv)},
-            {256 + +MOUSE::kButton4, IconTexture(L"Mouse5 "sv)},
+            {256 + +MOUSE::kButton4, IconTexture(L"Mouse5"sv)},
             {256 + +MOUSE::kButton5, IconTexture(L"Mouse6"sv)},
             {256 + +MOUSE::kButton6, IconTexture(L"Mouse7"sv)},
             {256 + +MOUSE::kButton7, IconTexture(L"Mouse8"sv)},
+            {256 + +MOUSE::kWheelUp, IconTexture(L"WheelUp"sv)},
+            {256 + +MOUSE::kWheelDown, IconTexture(L"WheelDown"sv)},
             {SkyPromptAPI::kMouseMove, IconTexture(L"mouse"sv)},
             {SkyPromptAPI::kSkyrim, IconTexture(L"skyrim"sv)},
         };

--- a/src/Input.cpp
+++ b/src/Input.cpp
@@ -417,12 +417,6 @@ namespace Input {
                     keys.push_back(Convert(key, RE::INPUT_DEVICE::kKeyboard));
                 }
                 for (const auto key : magic_enum::enum_values<MOUSE>()) {
-                    if (key == MOUSE::kWheelDown ||
-                        key == MOUSE::kWheelUp ||
-                        key == MOUSE::kButton4 // We don't have an icon for it
-                    ) {
-                        continue;
-                    }
                     keys.push_back(Convert(key, RE::INPUT_DEVICE::kMouse));
                 }
                 break;

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "skyprompt",
-  "version-string": "2.3.18.0",
+  "version-string": "2.3.19.0",
   "dependencies": [
     "spdlog",
     "rapidcsv",


### PR DESCRIPTION
## Summary

- Map the keyboard Up Arrow to the existing `Up` icon.
- Map mouse wheel up/down to the existing `WheelUp` and `WheelDown` icons.
- Fix the trailing space in the Mouse5 texture name.
- Make Mouse5 and both wheel directions available in the configurable key list.
- Bump SkyPrompt to `2.3.19`.

## Scope

Windows-key support and the separate PS4 key-picker issues are intentionally left out of this PR.

## Verification

- Audited the keyboard, mouse, and gamepad mappings against CommonLibVR-MIT.
- Confirmed `Up.png`, `Mouse5.png`, `WheelUp.png`, and `WheelDown.png` exist in the installed icon packs.
- Completed a clean Debug compile and link against CommonLibVR-MIT.
- Rebuilt after the bump and verified the DLL reports file version `2.3.19.0`.
- `git diff --check` passes.
- Confirmed the generated build had no MO2 deployment path.